### PR TITLE
make tests depend on config

### DIFF
--- a/ignite-base/.ignite.template
+++ b/ignite-base/.ignite.template
@@ -1,6 +1,8 @@
-{
-  "igniteVersion": "<%= igniteVersion %>",
-  "reactNativeVersion": "<%= reactNativeVersion %>",
-  "options": {},
-  "plugins": {}
+module.exports = {
+  igniteVersion: '<%= igniteVersion %>',
+  reactNativeVersion: '<%= reactNativeVersion %>',
+  options: {
+    testing: 'ava'
+  },
+  plugins: {}
 }

--- a/ignite-generator/src/component/index.es
+++ b/ignite-generator/src/component/index.es
@@ -1,7 +1,8 @@
-#! /usr/bin/env node
-'use strict'
-
 import Generators from 'yeoman-generator'
+import R from 'ramda'
+import { getConfig } from '../utilities'
+
+const igniteConfig = getConfig()
 
 const copyOverComponent = (context) => {
   // copy component template
@@ -18,13 +19,14 @@ const copyOverComponent = (context) => {
     { name: context.name }
   )
 
-  // create a component test
-  context.fs.copyTpl(
-    context.templatePath('component-test.js.template'),
-    context.destinationPath(`./Tests/Components/${context.name}Test.js`),
-    { name: context.name }
-  )
-
+  // create a component ava test
+  if (R.pathEq(['options', 'testing'], 'ava', igniteConfig)) {
+    context.fs.copyTpl(
+      context.templatePath('component-test.js.template'),
+      context.destinationPath(`./Tests/Components/${context.name}Test.js`),
+      { name: context.name }
+    )
+  }
 }
 
 class ComponentGenerator extends Generators.Base {

--- a/ignite-generator/src/utilities.js
+++ b/ignite-generator/src/utilities.js
@@ -1,7 +1,14 @@
-#! /usr/bin/env node
-'use strict'
-
 import fs from 'fs'
+import Shell from 'shelljs'
+
+// Get ignite config file
+export const getConfig = () => {
+  try {
+    return require(`${Shell.pwd()}/.ignite`)
+  } catch (e) {
+    return null
+  }
+}
 
 // Use this sparingly, as file contents are fickle!
 export const insertInFile = (theFile, theFind, theInsert, insertAfter = true) => {


### PR DESCRIPTION
## Please verify the following:
- [x] Everything works on iOS/Android
- [x] `ignite-base` **ava** tests pass
- [x] `fireDrill.sh` passed

## Describe your PR
Adjusting PR to work off of config file.  Sets precedent of reading config in generators.

